### PR TITLE
Fix React App API URL

### DIFF
--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -1,5 +1,5 @@
 const settings = {
-  REACT_APP_API_URL: 'http://localhost:81',
+  REACT_APP_API_URL: 'http://localhost:8000',
   ...process.env
 };
 export default settings;


### PR DESCRIPTION
The URL was working for me and Ben because we ran docker compose locally.

If someone was to follow the steps to run the local environment, they would have encountered issues. 